### PR TITLE
Features/scan rate config

### DIFF
--- a/app/app.ino
+++ b/app/app.ino
@@ -88,7 +88,7 @@ void setup() {
   Serial.println("");
 
   Serial.println("Initializing modbus ...");
-  errorCode = ModbusRTUClient.begin(9600);
+  errorCode = ModbusRTUClient.begin(config->modbus.serial_port.baud_rate);
   if (errorCode < 0){
     errorCode = -15;
     return;

--- a/app/app.ino
+++ b/app/app.ino
@@ -26,6 +26,7 @@ String mqttMessage;
 uint8_t lastSentReading = 0; //Stores last Input Reading sent to the broker
 unsigned long lastMillis = 0; // The time at which the sensors were last read.
 unsigned long lastStatusMillis = 0; // The time at which the sensors were last read.
+int telemetryFrequency = 15000;
 //queue stores cmd messages to be published - messages in queue are overwritten to prevent duplication
 // DynamicJsonDocument cmd(512);
 //can queue up to 5 commands
@@ -104,6 +105,8 @@ void setup() {
   }else{
     Serial.println("Success.");
   }
+
+  telemetryFrequency = config->modbus.telemetry_interval_sec * 1000;
 
   Serial.print("Setup message received events ...");
   RemoteConnMgr.RegisterOnMessageReceivedCallback(messageReceived);
@@ -286,8 +289,7 @@ int isWithinRange(int lower, int upper, int value, eLimitComparison eComparison)
 
 void loop() {
   //status LED freq should always be smaller than telem freq
-  int statusLedFrequency = 10000;
-  int telemetryFrequency = 15000;
+  int statusLedFrequency = min(10000, telemetryFrequency);
 
   //give a status update every few seconds or when an error is present
   if (millis() - lastStatusMillis > statusLedFrequency || errorCode != 0) {

--- a/app/src/ConfigurationManager.cpp
+++ b/app/src/ConfigurationManager.cpp
@@ -104,6 +104,14 @@ int ConfigurationManager::Load(char* configFileName, struct Config* config)
 
         //modbus settings
         Serial.println("reading modbus settings");
+        config->modbus.telemetry_interval_sec = doc[config->modbus.key]["telemetry_interval_sec"] | 10;
+        config->modbus.serial_port.baud_rate = doc[config->modbus.key][config->modbus.serial_port.key]["baud_rate"];
+        config->modbus.serial_port.stop_bits = doc[config->modbus.key][config->modbus.serial_port.key]["stop_bits"];
+        config->modbus.serial_port.parity_bits = doc[config->modbus.key][config->modbus.serial_port.key]["parity_bits"];
+        config->modbus.serial_port.data_bits = doc[config->modbus.key][config->modbus.serial_port.key]["data_bits"];
+        config->modbus.serial_port.flow_control = doc[config->modbus.key][config->modbus.serial_port.key]["flow_control"];
+        config->modbus.serial_port.flow_control = true;
+        
         JsonArray arr = jObj[config->modbus.key]["telemetry_registers"].as<JsonArray>();
         int i = 0;
 

--- a/app/src/ConfigurationManager.h
+++ b/app/src/ConfigurationManager.h
@@ -31,6 +31,18 @@ struct BrokerConfiguration
     int broker_retry_interval_sec;
 };
 
+/// @brief Serial port connection information
+struct SerialPortConfiguration
+{
+    bool formed = false;
+    const char* key = "serial_port";
+    int baud_rate = 9600;
+    int data_bits = 8;
+    int parity_bits = 0;
+    int stop_bits = 1;
+    bool flow_control = false;
+};
+
 /// @brief Controller information
 struct DeviceConfiguration
 {
@@ -76,6 +88,8 @@ struct ModbusConfiguration
 {
     bool formed = false;
     const char* key = "modbus";
+    int telemetry_interval_sec;
+    SerialPortConfiguration serial_port;
     ModbusParameter registers[50];
     ModbusConfigParameter configuration_registers[50];
 };


### PR DESCRIPTION
- Adds new settings to config.txt
- Update status LED every 10 sec unless publish freq is more frequent, then use that duration

## Configurable Publish Frequency
`modbus.telemetry_interval_sec`
- Defaults to 15 seconds

## Configurable RS485 Serial Port Settings
`modbus.serial_port.baud_rate`
- Defaults to 9600/8/0/1