### PR TITLE
add controller mac addr to config

### DIFF
--- a/app/app.ino
+++ b/app/app.ino
@@ -74,17 +74,17 @@ void setup() {
   Serial.print("Mac address: ");
   // Serial.println(config->broker.broker_retry_interval_sec);
   char hexCar[2];
-  sprintf(hexCar, "%02X", config->device.device_mac[0]);
+  sprintf(hexCar, "%02X", config->device.device_mac.b1);
   Serial.print(hexCar);
-  sprintf(hexCar, "%02X", config->device.device_mac[1]);
+  sprintf(hexCar, "%02X", config->device.device_mac.b2);
   Serial.print(hexCar);
-  sprintf(hexCar, "%02X", config->device.device_mac[2]);
+  sprintf(hexCar, "%02X", config->device.device_mac.b3);
   Serial.print(hexCar);
-  sprintf(hexCar, "%02X", config->device.device_mac[3]);
+  sprintf(hexCar, "%02X", config->device.device_mac.b4);
   Serial.print(hexCar);
-  sprintf(hexCar, "%02X", config->device.device_mac[4]);
+  sprintf(hexCar, "%02X", config->device.device_mac.b5);
   Serial.print(hexCar);
-  sprintf(hexCar, "%02X", config->device.device_mac[5]);
+  sprintf(hexCar, "%02X", config->device.device_mac.b6);
   Serial.print(hexCar);
   Serial.println("");
 

--- a/app/src/ConfigurationManager.cpp
+++ b/app/src/ConfigurationManager.cpp
@@ -95,10 +95,17 @@ int ConfigurationManager::Load(char* configFileName, struct Config* config)
         strlcpy(config->device.device_name,
                 doc[config->device.key]["device_name"] | "arduino",
                 sizeof(config->device.device_name));
-        //TODO: add support for mac address in config
-        // memccpy(config->device.device_mac,
-        //         doc[config->device.key]["device_mac"].as<JsonArray>(),
-        //         sizeof(config->device.device_mac));
+
+        Serial.print("reading mac address...");
+        config->device.device_mac.b1 = doc[config->device.key][config->device.device_mac.key]["b1"];
+        config->device.device_mac.b2 = doc[config->device.key][config->device.device_mac.key]["b2"];
+        config->device.device_mac.b3 = doc[config->device.key][config->device.device_mac.key]["b3"];
+        config->device.device_mac.b4 = doc[config->device.key][config->device.device_mac.key]["b4"];
+        config->device.device_mac.b5 = doc[config->device.key][config->device.device_mac.key]["b5"];
+        config->device.device_mac.b6 = doc[config->device.key][config->device.device_mac.key]["b6"];
+        config->device.device_mac.formed = true;
+        Serial.println("done.");
+
         config->device.formed = true;
         //app settings
 

--- a/app/src/ConfigurationManager.h
+++ b/app/src/ConfigurationManager.h
@@ -43,13 +43,24 @@ struct SerialPortConfiguration
     bool flow_control = false;
 };
 
+struct MacAddress
+{
+    bool formed = false;
+    const char* key = "controller_mac_address";
+    uint8_t b1;
+    uint8_t b2;
+    uint8_t b3;
+    uint8_t b4;
+    uint8_t b5;
+    uint8_t b6;
+};
+
 /// @brief Controller information
 struct DeviceConfiguration
 {
     bool formed = false;
     const char* key = "device";
-    //TODO: remove hardcoded mac address
-    uint8_t device_mac[6] {0x60, 0x52, 0xD0, 0x06, 0x70, 0x27};
+    MacAddress device_mac;
     char device_name[16];
     uint8_t ethernet_pin = 5;
 };

--- a/app/src/RemoteConnectionManager.cpp
+++ b/app/src/RemoteConnectionManager.cpp
@@ -22,8 +22,16 @@ int RemoteConnectionManager::Init(BrokerConfiguration config, DeviceConfiguratio
     int val;
     // Ethernet.init(_devConfig.ethernet_pin);   //CS pin for P1AM-ETH
     Ethernet.init(5);   //CS pin for P1AM-ETH
+    uint8_t mac[6] {
+        _devConfig.device_mac.b1,
+        _devConfig.device_mac.b2,
+        _devConfig.device_mac.b3,
+        _devConfig.device_mac.b4,
+        _devConfig.device_mac.b5,
+        _devConfig.device_mac.b6,
+        };
     //val = Ethernet.begin(_devConfig.device_mac, 10);  // Get IP from DHCP
-    val = Ethernet.begin(_devConfig.device_mac);  // Get IP from DHCP
+    val = Ethernet.begin(mac);  // Get IP from DHCP
     if (val == 0)
     {
         Serial.print("Ethernet failed to obtain DHCP address. Error code = ");


### PR DESCRIPTION
## Controller Ethernet MAC address Setup
In order to use the onboard ethernet module, the application must have the Mac address of the network adapter setup in the config.txt
- `device.controller_mac_address`
- each byte of the Mac address must be input as an integer value