### PR TITLE
added address offsets to config, apply them directly in load

### DIFF
--- a/app/app.ino
+++ b/app/app.ino
@@ -216,7 +216,7 @@ int processCommandQueue(){
             
             //modbus client writes off by 1
             int writeRes;
-            writeRes = ModbusRTUClient.holdingRegisterWrite(p.device_id, p.address-1, val);
+            writeRes = ModbusRTUClient.holdingRegisterWrite(p.device_id, p.address, val);
 
             if (writeRes > 0){
               return 3;
@@ -338,12 +338,12 @@ int publishTelemetry(){
       // Serial.println(param.address);
 
       // Serial.print("Beginning read ... ");
-      int regValue = ModbusRTUClient.holdingRegisterRead(param.device_id, param.address - 1);
+      int regValue = ModbusRTUClient.holdingRegisterRead(param.device_id, param.address);
       if (regValue < 0) 
       {
         //move to next register
         Serial.print("failed to read register ");
-        Serial.print(40000 + param.address - 1);
+        Serial.print(40000 + param.address);
         Serial.print(" ; ");
         Serial.println(ModbusRTUClient.lastError());
         return -7;

--- a/app/src/ConfigurationManager.cpp
+++ b/app/src/ConfigurationManager.cpp
@@ -132,7 +132,8 @@ int ConfigurationManager::Load(char* configFileName, struct Config* config)
             strlcpy(config->modbus.registers[i].topic,
                 value["topic"].as<char*>(),
                 sizeof(config->modbus.registers[i].topic));
-            config->modbus.registers[i].address = value["address"].as<int>();
+            config->modbus.registers[i].offset = value["offset"].as<int>();
+            config->modbus.registers[i].address = value["address"].as<int>() + config->modbus.registers[i].offset;
             config->modbus.registers[i].value = value["value"].as<int>();
             config->modbus.registers[i].device_id = value["device_id"].as<int>();
             config->modbus.registers[i].formed = true;
@@ -161,7 +162,8 @@ int ConfigurationManager::Load(char* configFileName, struct Config* config)
             strlcpy(config->modbus.configuration_registers[configIndex].topic,
                 value2["topic"].as<char*>(),
                 sizeof(config->modbus.configuration_registers[configIndex].topic));
-            config->modbus.configuration_registers[configIndex].address = value2["address"].as<int>();
+            config->modbus.configuration_registers[configIndex].offset = value2["offset"].as<int>();
+            config->modbus.configuration_registers[configIndex].address = value2["address"].as<int>() + config->modbus.configuration_registers[configIndex].offset;
             config->modbus.configuration_registers[configIndex].value = value2["value"].as<int>();
             config->modbus.configuration_registers[configIndex].device_id = value2["device_id"].as<int>();
             config->modbus.configuration_registers[i].upper_limit = value2["upper_limit"].as<int>();

--- a/app/src/ConfigurationManager.cpp
+++ b/app/src/ConfigurationManager.cpp
@@ -111,6 +111,7 @@ int ConfigurationManager::Load(char* configFileName, struct Config* config)
 
         //modbus settings
         Serial.println("reading modbus settings");
+        config->modbus.offset = doc[config->modbus.key]["offset"];
         config->modbus.telemetry_interval_sec = doc[config->modbus.key]["telemetry_interval_sec"] | 10;
         config->modbus.serial_port.baud_rate = doc[config->modbus.key][config->modbus.serial_port.key]["baud_rate"];
         config->modbus.serial_port.stop_bits = doc[config->modbus.key][config->modbus.serial_port.key]["stop_bits"];
@@ -132,8 +133,7 @@ int ConfigurationManager::Load(char* configFileName, struct Config* config)
             strlcpy(config->modbus.registers[i].topic,
                 value["topic"].as<char*>(),
                 sizeof(config->modbus.registers[i].topic));
-            config->modbus.registers[i].offset = value["offset"].as<int>();
-            config->modbus.registers[i].address = value["address"].as<int>() + config->modbus.registers[i].offset;
+            config->modbus.registers[i].address = value["address"].as<int>() + config->modbus.offset;
             config->modbus.registers[i].value = value["value"].as<int>();
             config->modbus.registers[i].device_id = value["device_id"].as<int>();
             config->modbus.registers[i].formed = true;
@@ -162,8 +162,7 @@ int ConfigurationManager::Load(char* configFileName, struct Config* config)
             strlcpy(config->modbus.configuration_registers[configIndex].topic,
                 value2["topic"].as<char*>(),
                 sizeof(config->modbus.configuration_registers[configIndex].topic));
-            config->modbus.configuration_registers[configIndex].offset = value2["offset"].as<int>();
-            config->modbus.configuration_registers[configIndex].address = value2["address"].as<int>() + config->modbus.configuration_registers[configIndex].offset;
+            config->modbus.configuration_registers[configIndex].address = value2["address"].as<int>() + config->modbus.offset;
             config->modbus.configuration_registers[configIndex].value = value2["value"].as<int>();
             config->modbus.configuration_registers[configIndex].device_id = value2["device_id"].as<int>();
             config->modbus.configuration_registers[i].upper_limit = value2["upper_limit"].as<int>();

--- a/app/src/ConfigurationManager.h
+++ b/app/src/ConfigurationManager.h
@@ -73,6 +73,7 @@ struct ModbusParameter
     char name[32];
     char units[16];
     char topic[64];
+    int offset;
     int address;
     int value;
     int device_id;
@@ -86,6 +87,7 @@ struct ModbusConfigParameter
     char name[32];
     char units[16];
     char topic[64];
+    int offset;
     int address;
     int value;
     int device_id;

--- a/app/src/ConfigurationManager.h
+++ b/app/src/ConfigurationManager.h
@@ -73,7 +73,6 @@ struct ModbusParameter
     char name[32];
     char units[16];
     char topic[64];
-    int offset;
     int address;
     int value;
     int device_id;
@@ -87,7 +86,6 @@ struct ModbusConfigParameter
     char name[32];
     char units[16];
     char topic[64];
-    int offset;
     int address;
     int value;
     int device_id;
@@ -101,6 +99,7 @@ struct ModbusConfiguration
 {
     bool formed = false;
     const char* key = "modbus";
+    int offset;
     int telemetry_interval_sec;
     SerialPortConfiguration serial_port;
     ModbusParameter registers[50];

--- a/config-fr800.txt
+++ b/config-fr800.txt
@@ -12,11 +12,11 @@
         "ethernet_pin" : 5
     },
     "modbus":{
+        "offset" : -1,
         "telemetry_registers":[
             {
                 "name" : "freqref",
                 "units" : "Hz",
-                "offset" : -1,
                 "address" : 205,
                 "value" : 0,
                 "device_id" : 1,
@@ -25,7 +25,6 @@
             {
                 "name" : "torque",
                 "units" : "ft-lbs",
-                "offset" : -1,
                 "address" : 207,
                 "value" : 0,
                 "device_id" : 1,
@@ -34,7 +33,6 @@
             {
                 "name" : "frequency",
                 "units" : "Hz",
-                "offset" : -1,
                 "address" : 201,
                 "value" : 0,
                 "device_id" : 1,
@@ -43,7 +41,6 @@
             {
                 "name" : "amperage",
                 "units" : "A",
-                "offset" : -1,
                 "address" : 202,
                 "value" : 0,
                 "device_id" : 1,
@@ -52,7 +49,6 @@
             {
                 "name" : "volts",
                 "units" : "V",
-                "offset" : -1,
                 "address" : 203,
                 "value" : 0,
                 "device_id" : 1,
@@ -61,7 +57,6 @@
             {
                 "name" : "dcbusvolts",
                 "units" : "V",
-                "offset" : -1,
                 "address" : 208,
                 "value" : 0,
                 "device_id" : 1,
@@ -70,7 +65,6 @@
             {
                 "name" : "inputkw",
                 "units" : "kW",
-                "offset" : -1,
                 "address" : 213,
                 "value" : 0,
                 "device_id" : 1,
@@ -79,7 +73,6 @@
             {
                 "name" : "motorhp",
                 "units" : "HP",
-                "offset" : -1,
                 "address" : 214,
                 "value" : 0,
                 "device_id" : 1,
@@ -88,7 +81,6 @@
             {
                 "name" : "motorrpm",
                 "units" : "RPM",
-                "offset" : -1,
                 "address" : 206,
                 "value" : 0,
                 "device_id" : 1,
@@ -97,7 +89,6 @@
             {
                 "name" : "vfdtemp",
                 "units" : "C",
-                "offset" : -1,
                 "address" : 298,
                 "value" : 0,
                 "device_id" : 1,
@@ -108,7 +99,6 @@
             {
                 "name" : "hp",
                 "units" : "kW/100",
-                "offset" : -1,
                 "address" : 1080,
                 "value" : 0,
                 "device_id" : 1,
@@ -120,7 +110,6 @@
             {
                 "name" : "poles",
                 "units" : "",
-                "offset" : -1,
                 "address" : 1081,
                 "value" : 0,
                 "device_id" : 1,
@@ -132,7 +121,6 @@
             {
                 "name" : "motorratedvolts",
                 "units" : "V/10",
-                "offset" : -1,
                 "address" : 1083,
                 "value" : 0,
                 "device_id" : 1,
@@ -144,7 +132,6 @@
             {
                 "name" : "motorratedamps",
                 "units" : "A/100",
-                "offset" : -1,
                 "address" : 1082,
                 "value" : 0,
                 "device_id" : 1,
@@ -156,7 +143,6 @@
             {
                 "name" : "currentlimit",
                 "units" : "A/100",
-                "offset" : -1,
                 "address" : 1009,
                 "value" : 0,
                 "device_id" : 1,
@@ -170,7 +156,6 @@
                 #range 0-30
                 "name" : "torquelimit",
                 "units" : "ft-lbs/10",
-                "offset" : -1,
                 "address" : 0000,
                 "value" : 0,
                 "device_id" : 1,
@@ -182,7 +167,6 @@
             {
                 "name" : "torqueboost",
                 "units" : "%/100",
-                "offset" : -1,
                 "address" : 1000,
                 "value" : 0,
                 "device_id" : 1,
@@ -194,7 +178,6 @@
             {
                 "name" : "carrierfrequency",
                 "units" : "kHz",
-                "offset" : -1,
                 "address" : 1072,
                 "value" : 0,
                 "device_id" : 1,
@@ -206,7 +189,6 @@
             {
                 "name" : "basefrequency",
                 "units" : "Hz/100",
-                "offset" : -1,
                 "address" : 1003,
                 "value" : 0,
                 "device_id" : 1,
@@ -218,7 +200,6 @@
             {
                 "name" : "acceltime",
                 "units" : "sec/10",
-                "offset" : -1,
                 "address" : 1007,
                 "value" : 0,
                 "device_id" : 1,
@@ -230,7 +211,6 @@
             {
                 "name" : "deceltime",
                 "units" : "sec/10",
-                "offset" : -1,
                 "address" : 1008,
                 "value" : 0,
                 "device_id" : 1,

--- a/config-fr800.txt
+++ b/config-fr800.txt
@@ -16,6 +16,7 @@
             {
                 "name" : "freqref",
                 "units" : "Hz",
+                "offset" : -1,
                 "address" : 205,
                 "value" : 0,
                 "device_id" : 1,
@@ -24,6 +25,7 @@
             {
                 "name" : "torque",
                 "units" : "ft-lbs",
+                "offset" : -1,
                 "address" : 207,
                 "value" : 0,
                 "device_id" : 1,
@@ -32,6 +34,7 @@
             {
                 "name" : "frequency",
                 "units" : "Hz",
+                "offset" : -1,
                 "address" : 201,
                 "value" : 0,
                 "device_id" : 1,
@@ -40,6 +43,7 @@
             {
                 "name" : "amperage",
                 "units" : "A",
+                "offset" : -1,
                 "address" : 202,
                 "value" : 0,
                 "device_id" : 1,
@@ -48,6 +52,7 @@
             {
                 "name" : "volts",
                 "units" : "V",
+                "offset" : -1,
                 "address" : 203,
                 "value" : 0,
                 "device_id" : 1,
@@ -56,6 +61,7 @@
             {
                 "name" : "dcbusvolts",
                 "units" : "V",
+                "offset" : -1,
                 "address" : 208,
                 "value" : 0,
                 "device_id" : 1,
@@ -64,6 +70,7 @@
             {
                 "name" : "inputkw",
                 "units" : "kW",
+                "offset" : -1,
                 "address" : 213,
                 "value" : 0,
                 "device_id" : 1,
@@ -72,6 +79,7 @@
             {
                 "name" : "motorhp",
                 "units" : "HP",
+                "offset" : -1,
                 "address" : 214,
                 "value" : 0,
                 "device_id" : 1,
@@ -80,6 +88,7 @@
             {
                 "name" : "motorrpm",
                 "units" : "RPM",
+                "offset" : -1,
                 "address" : 206,
                 "value" : 0,
                 "device_id" : 1,
@@ -88,6 +97,7 @@
             {
                 "name" : "vfdtemp",
                 "units" : "C",
+                "offset" : -1,
                 "address" : 298,
                 "value" : 0,
                 "device_id" : 1,
@@ -98,6 +108,7 @@
             {
                 "name" : "hp",
                 "units" : "kW/100",
+                "offset" : -1,
                 "address" : 1080,
                 "value" : 0,
                 "device_id" : 1,
@@ -109,6 +120,7 @@
             {
                 "name" : "poles",
                 "units" : "",
+                "offset" : -1,
                 "address" : 1081,
                 "value" : 0,
                 "device_id" : 1,
@@ -120,6 +132,7 @@
             {
                 "name" : "motorratedvolts",
                 "units" : "V/10",
+                "offset" : -1,
                 "address" : 1083,
                 "value" : 0,
                 "device_id" : 1,
@@ -131,6 +144,7 @@
             {
                 "name" : "motorratedamps",
                 "units" : "A/100",
+                "offset" : -1,
                 "address" : 1082,
                 "value" : 0,
                 "device_id" : 1,
@@ -142,6 +156,7 @@
             {
                 "name" : "currentlimit",
                 "units" : "A/100",
+                "offset" : -1,
                 "address" : 1009,
                 "value" : 0,
                 "device_id" : 1,
@@ -155,6 +170,7 @@
                 #range 0-30
                 "name" : "torquelimit",
                 "units" : "ft-lbs/10",
+                "offset" : -1,
                 "address" : 0000,
                 "value" : 0,
                 "device_id" : 1,
@@ -166,6 +182,7 @@
             {
                 "name" : "torqueboost",
                 "units" : "%/100",
+                "offset" : -1,
                 "address" : 1000,
                 "value" : 0,
                 "device_id" : 1,
@@ -177,6 +194,7 @@
             {
                 "name" : "carrierfrequency",
                 "units" : "kHz",
+                "offset" : -1,
                 "address" : 1072,
                 "value" : 0,
                 "device_id" : 1,
@@ -188,6 +206,7 @@
             {
                 "name" : "basefrequency",
                 "units" : "Hz/100",
+                "offset" : -1,
                 "address" : 1003,
                 "value" : 0,
                 "device_id" : 1,
@@ -199,6 +218,7 @@
             {
                 "name" : "acceltime",
                 "units" : "sec/10",
+                "offset" : -1,
                 "address" : 1007,
                 "value" : 0,
                 "device_id" : 1,
@@ -210,6 +230,7 @@
             {
                 "name" : "deceltime",
                 "units" : "sec/10",
+                "offset" : -1,
                 "address" : 1008,
                 "value" : 0,
                 "device_id" : 1,


### PR DESCRIPTION
@thompcd, Let me know what you think about applying the offsets directly to registers[x].address in the load function.
If we don't want to do that, I'll change it back to applying them where used.